### PR TITLE
Force Webpack 3.x in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yarn add --dev configduino
 For this sample project, I'll use webpack as a packager.
 
 ```
-yarn add --dev webpack
+yarn add --dev webpack@3
 ```
 
 We'll need babel to deal with ES6 and the transformation of the preact JSX


### PR DESCRIPTION
Webpack 4.x is out and has multiple breaking API changes (the plugin module system has been overhauled). Until everything's updated and verified working, probably best to just force webpack to 3.x in the README.

@madpilot I definitely couldn't be bothered working out what's happened in JS land since you shipped this 3 weeks ago (it's like 3 years in real life) but figured I'd save others the hassle I went through figuring out where things broke when I just did `yarn add webpack` :grinning: 